### PR TITLE
1.2.2 / fix ms querying UDP port on register

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "UnholyTrinity",
-    "version_number": "1.2.1",
+    "version_number": "1.2.2",
     "website_url": "https://github.com/xamionex/xamionex.UnholyTrinity",
     "description": "Quake Unholy Trinity similar gameplay in titanfall 2",
     "dependencies": []

--- a/mods/xamionex.UnholyTrinity/mod.json
+++ b/mods/xamionex.UnholyTrinity/mod.json
@@ -1,7 +1,7 @@
 {
 	"Name": "xamionex.UnholyTrinity",
 	"Description": "This is my custom weapons for the UnholyTrinity server\n\nThis is a server side script, no need for clients to download",
-	"Version": "1.2.1",
+	"Version": "1.2.2",
 	"LoadPriority": 2,
 	"Scripts":[
 		{

--- a/mods/xamionex.UnholyTrinity/mod/scripts/vscripts/UnholyTrinity.nut
+++ b/mods/xamionex.UnholyTrinity/mod/scripts/vscripts/UnholyTrinity.nut
@@ -8,6 +8,12 @@ string uht_gamemode
 
 void function UnholyTrinity_Init()
 {
+	thread ThreadUnholyTrinity()
+}
+
+void function ThreadUnholyTrinity()
+{
+	wait 5.0 // this wait is needed otherwise master server can't connect to game session if you change the map immediately.
 	uht_wenttolobbyfirst = GetConVarInt( "uht_wenttolobbyfirst" )
 
 	if( uht_wenttolobbyfirst == 0)
@@ -30,12 +36,8 @@ void function UnholyTrinity_Init()
 		GameRules_ChangeMap( "mp_lobby", "private_match" )
 		SetConVarInt( "uht_wenttolobbyfirst", 1 )
 	}
-	thread ThreadUnholyTrinity()
-}
 
-void function ThreadUnholyTrinity()
-{
-	wait 2.0
+	wait 2.0 // just wait a bit between mapchange, why not
 
 	if( GetMapName() == "mp_lobby" )
 	{


### PR DESCRIPTION
since ms now checks for udp gameport it will throw an error, because we change the map to mp_lobby too fast. waiting 5 seconds fixes that issue.